### PR TITLE
- add integration with train network for players

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -28,7 +28,8 @@
 require("config")
 
 
-replaceCarriage = require("__Robot256Lib__/script/carriage_replacement").replaceCarriage
+-- Wrapped by local replaceCarriage function
+replaceCarriageFunc = require("__Robot256Lib__/script/carriage_replacement").replaceCarriage
 blueprintLib = require("__Robot256Lib__/script/blueprint_replacement")
 saveRestoreLib = require("__Robot256Lib__/script/save_restore")
 
@@ -371,6 +372,22 @@ function clearVehicle(vehicle, flags)
   end
 end
 
+function replaceCarriage(carriage, newName, raiseBuilt, raiseDestroy, flip)
+  -- The train id will change when the carriage is replaced
+  local old_id = carriage.train.id
+
+  local wagon = replaceCarriageFunc(carriage, newName, raiseBuilt, raiseDestroy, flip)
+
+  -- Train Network for Players tracks trains by their id, which changes when carriages
+  -- are replaced
+  if wagon and wagon.valid then
+    if remote.interfaces["TNfP"] and remote.interfaces["TNfP"].update_train_id then
+      remote.call("TNfP", "update_train_id", wagon.train, old_id)
+    end
+  end
+
+  return wagon
+end
 
 --== ON_PLAYER_USED_CAPSULE ==--
 -- Queues load/unload data when player clicks with the winch.


### PR DESCRIPTION
Hey there,

I had a request https://github.com/leehuk/factorio-tnfp/issues/12 to add integration between TNfP and Vehicle Wagon 2, as tnfp tracks trains by their train.id field -- this changes when vehicle wagon 2 swaps the wagons around between loaded/unloaded and tnfp then notices the original trains no longer valid for use

Looked feasible to wrap the wagon replacement with a hook to notify tnfp, which can then handle the swap gracefully

Could you let me know what you think and whether you'd be up for merging it please?

Cheers, Lee H

